### PR TITLE
Put session secret in .env

### DIFF
--- a/.env.EXAMPLE
+++ b/.env.EXAMPLE
@@ -1,3 +1,4 @@
 DB_NAME='jk_db'
 DB_PASSWORD=''
 DB_USER=''
+SESSION_SECRET='babybottle'

--- a/server.js
+++ b/server.js
@@ -21,7 +21,7 @@ const PORT = process.env.PORT || 3001;
 const hbs = exphbs.create({ helpers });
 
 const sess = {
-	secret: 'Super secret secret',
+	secret: process.env.SESSION_SECRET,
 	cookie: {
 		// maxAge sets the maximum age for the session to be active. Listed in milliseconds.
 		// 15 minutes


### PR DESCRIPTION
I just realised we should be hiding the session secret in .env. Not a big issue, but it would be good to follow best practice
```sh
heroku config set:SESSION_SECRET={secret}
```